### PR TITLE
fixed annoying scrollbar snapping

### DIFF
--- a/static/scss/scoreboard.scss
+++ b/static/scss/scoreboard.scss
@@ -1,5 +1,9 @@
-html,body,.full-height {
-    height: 100%;
+html {
+    overflow-y: scroll;
+
+    &,body,.full-height {
+        height: 100%;
+    }
 }
 
 body {
@@ -338,4 +342,8 @@ table.team-players{
             text-align: center;
         }
     }
+}
+
+.modal {
+    overflow-y: auto;
 }


### PR DESCRIPTION
[Resolves #49] Pretty self explanatory. While maybe not the best solution long-term, it vastly improves site usability on non-osx devices (which have a 0-width scrollbar).