### PR TITLE
Tests for /api/users and /api/page

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = .

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
-source = .
+source = scoreboard
 omit = scoreboard/tests/*
 branch = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,4 @@
 [run]
 source = .
+omit = scoreboard/tests/*
+branch = True

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,21 @@
+# Compiled, swap files
 *.pyc
-/config.py
 *.swp
+.virtualenv
+
+# Runtime data
+/config.py
 *.db
 /attachments
 /attachments/**
-static/js/app.min.js
-.virtualenv
-lib
+
+# Generated files
+/static/js/app.min.js
 /static/css/*.css
+
+# Appengine libraries
+lib
+
+# Python coverage toold
+.coverage
+htmlcov

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,11 @@ scss:
 		echo "Making $$i";\
 		$(PYSCSS) -o static/css/$${i%.scss}.css static/scss/$$i;\
 	done
+
+tests:
+	python main.py runtests
+
+coverage:
+	coverage run main.py runtests
+	coverage html
+	xdg-open htmlcov/index.html

--- a/scoreboard/cache.py
+++ b/scoreboard/cache.py
@@ -22,6 +22,8 @@ from werkzeug.contrib import cache
 
 from scoreboard import main
 
+app = main.get_app()
+
 
 class CacheWrapper(object):
 
@@ -41,7 +43,7 @@ class CacheWrapper(object):
         return getattr(self._cache, name)
 
 
-global_cache = CacheWrapper(main.get_app())
+global_cache = CacheWrapper(app)
 
 
 def rest_cache(f_or_key):

--- a/scoreboard/controllers.py
+++ b/scoreboard/controllers.py
@@ -79,7 +79,7 @@ def register_user(email, nick, password, team_id=None,
         models.ScoreHistory.add_entry(team)
         models.commit()
     app.logger.info('User %s <%s> registered from IP %s.',
-                    nick, email, flask.request.access_route[0])
+                    nick, email, flask.request.remote_addr)
     return user
 
 

--- a/scoreboard/csrfutil.py
+++ b/scoreboard/csrfutil.py
@@ -73,6 +73,8 @@ def csrf_protection_request():
     """Add CSRF Protection to all non-GET/non-HEAD requests."""
     if flask.request.method in ('GET', 'HEAD'):
         return
+    if app.config.get('TESTING'):
+        return
     header = flask.request.headers.get('X-XSRF-TOKEN')
     token = header or flask.request.values.get('csrftoken')
     if not token or not verify_csrf_token(token):

--- a/scoreboard/tests/base.py
+++ b/scoreboard/tests/base.py
@@ -85,12 +85,16 @@ class AuthenticatedClient(object):
     """Like TestClient, but authenticated."""
     def __init__(self, client):
         self.client = client
+        self.team = models.Team.create('team')
+        self.user = models.User.create('auth@example.com', 'Authenticated',
+                'hunter2', team=self.team)
+        models.db.session.commit()
 
     def __enter__(self):
         rv = self.client.__enter__()
         with rv.session_transaction() as sess:
-            sess['user'] = 1
-            sess['team'] = 1
+            sess['user'] = self.user.uid
+            sess['team'] = self.team.tid
         return rv
 
     def __exit__(self, *args, **kwargs):
@@ -100,10 +104,16 @@ class AuthenticatedClient(object):
 class AdminClient(AuthenticatedClient):
     """Like TestClient, but admin."""
 
+    def __init__(self, client):
+        self.client = client
+        self.user = models.User.create('admin@example.com', 'Admin', 'hunter2')
+        self.user.admin = True
+        models.db.session.commit()
+
     def __enter__(self):
         rv = self.client.__enter__()
         with rv.session_transaction() as sess:
-            sess['user'] = 1
+            sess['user'] = self.user.uid
             sess['admin'] = True
         return rv
 

--- a/scoreboard/tests/base.py
+++ b/scoreboard/tests/base.py
@@ -75,7 +75,7 @@ class RestTestCase(BaseTestCase):
         event.remove(*self._sql_listen_args)
         super(RestTestCase, self).tearDown()
 
-    def _count_query(self):
+    def _count_query(self, *unused_args):
         self._query_count += 1
 
 

--- a/scoreboard/tests/base.py
+++ b/scoreboard/tests/base.py
@@ -68,8 +68,8 @@ class RestTestCase(BaseTestCase):
         self._sql_listen_args = (models.db.engine, 'before_cursor_execute',
                 self._count_query)
         event.listen(*self._sql_listen_args)
-        self.authenticated_client = AuthenticatedClient(self.client)
         self.admin_client = AdminClient(self.client)
+        self.authenticated_client = AuthenticatedClient(self.client)
 
     def tearDown(self):
         if self._query_count:
@@ -83,6 +83,10 @@ class RestTestCase(BaseTestCase):
 
 class AuthenticatedClient(object):
     """Like TestClient, but authenticated."""
+
+    def __getattr__(self, attr):
+        return getattr(self.client, attr)
+
     def __init__(self, client):
         self.client = client
         self.team = models.Team.create('team')

--- a/scoreboard/tests/rest_test.py
+++ b/scoreboard/tests/rest_test.py
@@ -15,8 +15,9 @@
 
 import flask
 
-from scoreboard import rest
 from scoreboard.tests import base
+from scoreboard import models
+from scoreboard import rest
 
 
 class ConfigzTest(base.RestTestCase):
@@ -36,3 +37,18 @@ class ConfigzTest(base.RestTestCase):
         with self.admin_client as c:
             response = c.get(self.PATH)
             self.assert200(response)
+
+
+class PageTest(base.RestTestCase):
+
+    PATH = '/api/page/home'
+
+    def testGetAnonymous(self):
+        page = models.Page()
+        page.path = 'home'
+        page.title = 'Home'
+        page.contents = 'Home Page'
+        models.db.session.add(page)
+        models.db.session.commit()
+        response = self.client.get(self.PATH)
+        self.assert200(response)

--- a/scoreboard/tests/rest_test.py
+++ b/scoreboard/tests/rest_test.py
@@ -180,3 +180,38 @@ class UserTest(base.RestTestCase):
             self.assertEqual(resp.json['uid'], flask.session['user'])
             self.assertEqual(resp.json['admin'], flask.session['admin'])
             self.assertEqual(resp.json['team_tid'], flask.session['team'])
+
+    def testRegisterUserTeam(self):
+        team = self.authenticated_client.team
+        data = {
+            'email': 'test@example.com',
+            'nick': 'test3',
+            'password': 'test3',
+            'team_id': team.tid,
+            'team_name': None,
+            'team_code': team.code,
+        }
+        with self.client as c:
+            resp = c.post('/api/users', data=json.dumps(data),
+                    content_type='application/json')
+            self.assert200(resp)
+            self.assertItemsEqual(self.USER_FIELDS, resp.json.keys())
+            self.assertEqual(resp.json['uid'], flask.session['user'])
+            self.assertEqual(resp.json['admin'], flask.session['admin'])
+            self.assertEqual(resp.json['team_tid'], flask.session['team'])
+            self.assertEqual(team.tid, resp.json['team_tid'])
+
+    def testRegisterUserTeamNoCode(self):
+        team = self.authenticated_client.team
+        data = {
+            'email': 'test@example.com',
+            'nick': 'test3',
+            'password': 'test3',
+            'team_id': team.tid,
+            'team_name': None,
+            'team_code': 'xxx',
+        }
+        with self.client as c:
+            resp = c.post('/api/users', data=json.dumps(data),
+                    content_type='application/json')
+            self.assert400(resp)

--- a/scoreboard/tests/rest_test.py
+++ b/scoreboard/tests/rest_test.py
@@ -52,3 +52,8 @@ class PageTest(base.RestTestCase):
         models.db.session.commit()
         response = self.client.get(self.PATH)
         self.assert200(response)
+        self.assertEqual(page.title, response.json['title'])
+        self.assertEqual(page.contents, response.json['contents'])
+
+    def testGetNonExistent(self):
+        self.assert404(self.client.get(self.PATH))


### PR DESCRIPTION
This is more progress on unit testing.  In addition to testing /api/users and /api/page, it also adds python coverage support and fixes an issue found in the cache while writing the tests.