### PR TITLE
Split team invite code from session secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Author: David Tomaschik <dwt@google.com>
         SQLALCHEMY_DATABASE_URI = 'mysql://username:password@server/db'
         #SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://username:password@server/db'
         SECRET_KEY = 'Some Random Value For Session Keys'
+        TEAM_SECRET_KEY = SECRET_KEY
         TITLE = 'FakeCTF'
         TEAMS = True
         ATTACHMENT_DIR = 'attachments'
@@ -38,7 +39,6 @@ Author: David Tomaschik <dwt@google.com>
   
         COUNT_QUERIES = True
         SQLALCHEMY_ECHO = True 
-
 
 5. Create the database:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Author: David Tomaschik <dwt@google.com>
         SQLALCHEMY_DATABASE_URI = 'mysql://username:password@server/db'
         #SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://username:password@server/db'
         SECRET_KEY = 'Some Random Value For Session Keys'
-        TEAM_SECRET_KEY = SECRET_KEY
+        TEAM_SECRET_KEY = 'Another Random Value For Team Invite Codes'
         TITLE = 'FakeCTF'
         TEAMS = True
         ATTACHMENT_DIR = 'attachments'

--- a/config.py
+++ b/config.py
@@ -17,6 +17,9 @@
 SQLALCHEMY_DATABASE_URI = 'sqlite:////tmp/scoreboard.db'
 SQLALCHEMY_TRACK_MODIFICATIONS = True
 SECRET_KEY = 'CHANGEME CHANGEME CHANGEME'
+# Set TEAM_SECRET_KEY to a unique value so that you can rotate session
+# secrets (SECRET_KEY) without affecting team invite codes.
+TEAM_SECRET_KEY = SECRET_KEY
 TITLE = 'CTF Scoreboard Dev'
 TEAMS = True
 ATTACHMENT_BACKEND = 'file:///tmp/attachments'

--- a/scoreboard/config_defaults.py
+++ b/scoreboard/config_defaults.py
@@ -34,6 +34,7 @@ class Defaults(object):
         SCOREBOARD_ZEROS = True
         SCORING = 'plain'
         SECRET_KEY = None
+        TEAM_SECRET_KEY = None
         SESSION_COOKIE_HTTPONLY = True
         SESSION_COOKIE_SECURE = True
         SYSTEM_NAME = 'root'

--- a/scoreboard/models.py
+++ b/scoreboard/models.py
@@ -59,7 +59,7 @@ class Team(db.Model):
 
     @property
     def code(self):
-        return hmac.new(app.config.get('SECRET_KEY'), self.name.encode('utf-8')).hexdigest()[:12]
+        return hmac.new(app.config.get('TEAM_SECRET_KEY'), self.name.encode('utf-8')).hexdigest()[:12]
 
     @property
     def solves(self):


### PR DESCRIPTION
Gives ability to rotate session secrets without affecting team invite
codes. Perhaps useful if we need to make changes that affect user
cookies without breaking any team communications.