### PR TITLE
Requirements missing flask-testing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pytz
 six
 wsgiref
 Flask-Scss
+Flask-Testing


### PR DESCRIPTION
Not sure if this was added in another branch, but it doesn't seem to be in master yet.