### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ A big thanks to the following projects used to build this:
 
 - [Flask](http://flask.pocoo.org/)
 - [Flask-SQLAlchemy](https://pythonhosted.org/Flask-SQLAlchemy/)
-- [Flask-RESTful](http://flask-restful.readthedocs.org/en/latest/)
+- [Flask-RESTful](https://flask-restful.readthedocs.io/en/latest/)
 - [SQLAlchemy](http://www.sqlalchemy.org/)
 - [AngularJS](https://angularjs.org/)
 - [jQuery](https://jquery.com/)


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.