### PR TITLE
Load the config file only when loaded as a WSGI app.

### DIFF
--- a/scoreboard/main.py
+++ b/scoreboard/main.py
@@ -41,7 +41,6 @@ def create_app(config=None):
     if config is not None:
         app.config.update(**config)
 
-    load_config_file(app)
     if not on_appengine():
         #Configure Scss to watch the files
         scss_compiler = flask_scss.Scss(app, static_dir='static/css', asset_dir='static/scss')

--- a/scoreboard/wsgi.py
+++ b/scoreboard/wsgi.py
@@ -17,6 +17,7 @@ from scoreboard import rest
 from scoreboard import views
 
 app = main.get_app()
+main.load_config_file(app)
 
 # Used here to catch accidental removal
 _modules_for_views = (rest, views)


### PR DESCRIPTION
The fix in #85 results in the config file being loaded any time an app object is created, despite the fact that #78 was specifically intended to **prevent** this behavior.  (#85 was correct that the config file was not being properly loaded, however.)  This commit moves the loading to the WSGI app, and not to any instantiation of an app -- this way, the app can be loaded in tests without loading the config file.