### PR TITLE
[Resolve #87] Somehow the tag service was missing a create option

### DIFF
--- a/static/js/services/challenges.js
+++ b/static/js/services/challenges.js
@@ -42,6 +42,7 @@ challengeServices.service('tagService', [
 
         this.get = this.res.get;
         this.save = this.res.save;
+        this.create = this.res.create;
         this.delete = this.res.delete;
 
         this.getList = function(callback) {


### PR DESCRIPTION
Not sure exactly how this happened, but here's the fix. 