### PR TITLE
Added deployment with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:jessie
+
+RUN apt-get update && apt-get install -y \
+    nginx \
+    python \
+    python-pip \
+    supervisor \
+    uwsgi \
+    uwsgi-plugin-python \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+COPY doc/nginx.conf /etc/nginx/sites-enabled/default
+COPY doc/docker/supervisord.conf /etc/supervisor/conf.d/
+
+COPY . /opt/scoreboard
+WORKDIR /opt/scoreboard
+
+RUN python main.py createdb
+RUN chmod 766 /tmp/scoreboard*
+
+CMD ["/usr/bin/supervisord"]

--- a/doc/docker/supervisord.conf
+++ b/doc/docker/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+
+[program:uwsgi]
+command=/usr/bin/uwsgi --ini /opt/scoreboard/doc/docker/uwsgi.ini
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=/usr/sbin/nginx
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/doc/docker/uwsgi.ini
+++ b/doc/docker/uwsgi.ini
@@ -1,0 +1,13 @@
+# Sample uWSGI config file
+[uwsgi]
+chdir = /opt/scoreboard
+socket = 127.0.0.1:9000
+processes = 4
+threads = 2
+master = true
+module = scoreboard.wsgi
+callable = app
+uid = nobody
+gid = nogroup
+daemonize = /var/log/uwsgi/app/uwsgi.log
+plugins = python


### PR DESCRIPTION
I created a basic Dockerfile and setup to run a ctf.  It uses nginx and uwsgi with supervisord to deploy the app.

For a simple run:
```
docker build -t ctf .
docker run ctf
```

I only ran it with the "default" SQLite database in /tmp/.  Another database could still be used by changing the config file.  This could possibly be enhanced later by using the functionality of docker-compose or similar.




