### PR TITLE
Allow anonymous users to download attachments.

### DIFF
--- a/scoreboard/views.py
+++ b/scoreboard/views.py
@@ -66,19 +66,19 @@ def render_index():
 
 
 @app.route('/attachment/<filename>')
-@utils.login_required
 def download(filename):
     """Download an attachment."""
 
     attachment = models.Attachment.query.get_or_404(filename)
-    valid = models.User.current().admin
+    cuser = models.User.current()
+    valid = cuser and cuser.admin
     for ch in attachment.challenges:
         if ch.unlocked:
             valid = True
             break
     if not valid:
         flask.abort(404)
-    app.logger.info('Download of %s by %r.', attachment, models.User.current())
+    app.logger.info('Download of %s by %r.', attachment, cuser or "Anonymous")
 
     return attachments.backend.send(attachment)
 

--- a/scoreboard/views.py
+++ b/scoreboard/views.py
@@ -19,7 +19,6 @@ from werkzeug import exceptions
 from scoreboard import attachments
 from scoreboard import main
 from scoreboard import models
-from scoreboard import utils
 
 app = main.get_app()
 


### PR DESCRIPTION
This still validates that the challenge is open or the current user is
an admin.

Fixes #176.