### PR TITLE
hmac now requires digestmod

### DIFF
--- a/scoreboard/models.py
+++ b/scoreboard/models.py
@@ -67,7 +67,7 @@ class Team(db.Model):
         secret_key = (app.config.get('TEAM_SECRET_KEY') or
                       app.config.get('SECRET_KEY'))
         return hmac.new(utils.to_bytes(secret_key),
-                        self.name.encode('utf-8')).hexdigest()[:12]
+                        self.name.encode('utf-8'),hashlib.sha1).hexdigest()[:12]
 
     @property
     def solves(self):


### PR DESCRIPTION
Added  ",hashlib.sha1" to meet new hmac requirement to include digestmod.

https://docs.python.org/3/library/hmac.html

"""
Changed in version 3.4: Parameter key can be a bytes or bytearray object. Parameter msg can be of any type supported by hashlib. Parameter digestmod can be the name of a hash algorithm.
"""