### PR TITLE
Dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ branch, which will only be getting security & bug fixes.
 4. Write a config.py for your relevant installation.  An example is provided in
    config.example.py.
 
-        SQLALCHEMY_DATABASE_URI = 'mysql://username:password@server/db'
+        SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://username:password@server/db'
         #SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://username:password@server/db'
         SECRET_KEY = 'Some Random Value For Session Keys'
         TEAM_SECRET_KEY = 'Another Random Value For Team Invite Codes'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ Jinja2
 MarkupSafe
 PyMySQL
 SQLAlchemy<1.4.0
-Werkzeug<1.0.0
+Werkzeug
+cachelib
 aniso8601
 argparse
 itsdangerous

--- a/scoreboard/cache.py
+++ b/scoreboard/cache.py
@@ -17,7 +17,8 @@ import functools
 import json
 import flask
 
-from werkzeug.contrib import cache
+from cachelib import MemcachedCache, SimpleCache, NullCache
+
 
 from scoreboard import main
 
@@ -30,11 +31,11 @@ class CacheWrapper(object):
         cache_type = app.config.get('CACHE_TYPE')
         if cache_type == 'memcached':
             host = app.config.get('MEMCACHE_HOST')
-            self._cache = cache.MemcachedCache([host])
+            self._cache = MemcachedCache([host])
         elif cache_type == 'local':
-            self._cache = cache.SimpleCache()
+            self._cache = SimpleCache()
         else:
-            self._cache = cache.NullCache()
+            self._cache = NullCache()
 
     def __getattr__(self, name):
         return getattr(self._cache, name)

--- a/scoreboard/csrfutil.py
+++ b/scoreboard/csrfutil.py
@@ -18,9 +18,10 @@ import flask
 import functools
 import hashlib
 import hmac
-import jinja2
 import struct
 import time
+
+from markupsafe import Markup
 
 from scoreboard import main
 from scoreboard import utils
@@ -74,7 +75,7 @@ def csrf_protect(f):
 def get_csrf_field(*args, **kwargs):
     """Render a CSRF field."""
     token = get_csrf_token(*args, **kwargs)
-    field = jinja2.Markup(
+    field = Markup(
         '<input type="hidden" name="csrftoken" value="%s" />')
     return field % token
 

--- a/scoreboard/tests/base.py
+++ b/scoreboard/tests/base.py
@@ -73,7 +73,7 @@ class BaseTestCase(flask_testing.TestCase):
             self.app._SAVED_CONFIG = copy.deepcopy(app.config)
         models.db.init_app(app)
         models.db.create_all()
-        cache.global_cache = cache.cache.NullCache()  # Reset cache
+        cache.global_cache = cache.NullCache()  # Reset cache
 
     def tearDown(self):
         models.db.session.remove()

--- a/scoreboard/tests/cache_test.py
+++ b/scoreboard/tests/cache_test.py
@@ -27,7 +27,7 @@ class BaseCacheTest(base.BaseTestCase):
 
     def setUp(self):
         super(BaseCacheTest, self).setUp()
-        cache.global_cache = cache.cache.SimpleCache()
+        cache.global_cache = cache.SimpleCache()
 
     def makeMockGet(self, cache_type, cache_host=None):
         orig_config = self.app.config

--- a/scoreboard/tests/csrfutil_test.py
+++ b/scoreboard/tests/csrfutil_test.py
@@ -15,7 +15,7 @@
 import struct
 import time
 
-import jinja2
+from markupsafe import Markup
 from werkzeug import exceptions
 
 from scoreboard.tests import base
@@ -116,7 +116,7 @@ class CSRFUtilTest(base.BaseTestCase):
         mock_get_csrf_token.return_value = mock_value
         rv = csrfutil.get_csrf_field(user='foo')
         mock_get_csrf_token.assert_called_once_with(user='foo')
-        self.assertTrue(isinstance(rv, jinja2.Markup))
+        self.assertTrue(isinstance(rv, Markup))
         self.assertTrue(mock_value in str(rv))
 
     @mock.patch.object(csrfutil, 'verify_csrf_token')


### PR DESCRIPTION
This PR includes ~two~ three updates to resolve issues recently encountered when setting up a new `debian:buster`-image based installation:

1. Latest `Flask` library is no longer compatible with `Werkzeug<1.0.0` (at least since [Flask 2.0.0](https://flask.palletsprojects.com/en/2.1.x/changes/#version-2-0-0)). The changes here remove the `Werkzeug` version pin from requirements, and make a small update to use `cachelib` for functionality extracted to its own library ([ref](https://werkzeug.palletsprojects.com/en/0.16.x/contrib/cache/)).
2. Small change to migrate `jinja2.Markup()` usage to `markupsafe.Markup()` for similar library deprecations ([ref](https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-0-1)).
3. Updates the MySQL connection string in README to specify using the `pymysql` driver included in the requirements file ([ref](https://docs.sqlalchemy.org/en/13/dialects/mysql.html#module-sqlalchemy.dialects.mysql.pymysql)).